### PR TITLE
Ensure the default, unused passenger.conf file is removed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,11 @@
    - nginx-extras
    - passenger
 
+- name: Ensure default, unused passenger.conf file is removed.
+  file:
+    path: /etc/nginx/passenger.conf
+    state: absent
+
 # Nginx and passenger configuration.
 - name: Copy Nginx configuration into place.
   template:


### PR DESCRIPTION
Phusion's nginx-extras package creates /etc/nginx/passenger.conf which is
then referenced by the default /etc/nginx/nginx.conf.

Since this role defines Passenger directives in passenger.conf directly,
and does NOT reference the default passenger.conf, this simply removes
the default passenger.conf provided by Phusion's nginx-extras package
to reduce the chance of confusion.