### PR TITLE
Debian 9 compatibility, hkp_port variable and dirmngr fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Values for passenger configuration directives inside `nginx.conf`. These default
 
 Nginx directives.
 
+In order to install Passenger, the associated public apt key must be imported
+from `keyserver.ubuntu.com`. If target hosts cannot connect to the default HKP
+port on that keyserver (which is tcp/11371), you can try to use another port,
+e.g.:
+
+    hkp_port: 80
+
+this will make the hosts connect to the keyserver through the standard HTTP
+port.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Values for passenger configuration directives inside `nginx.conf`. These default
 
 Nginx directives.
 
-In order to install Passenger, the associated public apt key must be imported
-from `keyserver.ubuntu.com`. If target hosts cannot connect to the default HKP
-port on that keyserver (which is tcp/11371), you can try to use another port,
-e.g.:
+In order to install Passenger, the associated public apt key will be imported
+from `keyserver.ubuntu.com`.
+
+If target hosts cannot connect to the default HKP port on that keyserver
+(which is tcp/11371), you can try to use another port, e.g.:
 
     hkp_port: 80
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ nginx_worker_processes: "{{ ansible_processor_vcpus | default(ansible_processor_
 nginx_worker_connections: "768"
 nginx_keepalive_timeout: "65"
 nginx_remove_default_vhost: true
+
+hkp_port: 11371

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 # Passenger repository setup.
 - name: Add Passenger apt key.
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: "hkp://keyserver.ubuntu.com:{{ hkp_port }}"
     id: 561F9B9CAC40B2F7
     state: present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,12 @@
     nginx_user: "{{ __nginx_user }}"
   when: nginx_user is not defined
 
+# Install dirmngr (required by apt-key).
+- name: Install certificate management service.
+  apt:
+    name: dirmngr
+    state: present
+
 # Passenger repository setup.
 - name: Add Passenger apt key.
   apt_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,25 +30,27 @@
     state: present
     update_cache: true
 
-- name: Install Nginx and Passenger (< Ubuntu 18.04 or Debian).
+- name: Install Nginx and Passenger (Ubuntu < 18.04 or Debian < 9).
   apt:
     name:
       - nginx-extras
       - passenger
     state: present
-  when: |
-    ansible_distribution != 'Ubuntu'
-    or ansible_distribution_version != '18.04'
+  when: ( ansible_distribution == 'Ubuntu' and
+        ansible_distribution_version < '18.04' ) or
+        ( ansible_distribution == 'Debian' and
+          ansible_distribution_version < '9' )
 
-- name: Install Nginx and Passenger (Ubuntu 18.04).
+- name: Install Nginx and Passenger (Ubuntu >= 18.04 or Debian >= 9).
   apt:
     name:
       - nginx
       - libnginx-mod-http-passenger
     state: present
-  when:
-    - ansible_distribution == 'Ubuntu'
-    - ansible_distribution_version == '18.04'
+  when: ( ansible_distribution == 'Ubuntu' and
+        ansible_distribution_version >= '18.04' ) or
+        ( ansible_distribution == 'Debian' and
+          ansible_distribution_version >= '9' )
 
 - name: Ensure passenger module is enabled (Ubuntu 18.04 only).
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,14 +52,15 @@
         ( ansible_distribution == 'Debian' and
           ansible_distribution_version >= '9' )
 
-- name: Ensure passenger module is enabled (Ubuntu 18.04 only).
+- name: Ensure passenger module is enabled (Ubuntu >= 18.04 or Debian >= 9).
   file:
     src: /usr/share/nginx/modules-available/mod-http-passenger.load
     dest: /etc/nginx/modules-enabled/50-mod-http-passenger.conf
     state: link
-  when:
-    - ansible_distribution == 'Ubuntu'
-    - ansible_distribution_version == '18.04'
+  when: ( ansible_distribution == 'Ubuntu' and
+        ansible_distribution_version >= '18.04' ) or
+        ( ansible_distribution == 'Debian' and
+          ansible_distribution_version >= '9' )
 
 # Nginx and passenger configuration.
 - name: Copy Nginx configuration into place.

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -3,7 +3,8 @@ user {{ nginx_user }};
 worker_processes {{ nginx_worker_processes }};
 pid /run/nginx.pid;
 
-{% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic' %}
+{% if ( ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('18.04', '>=') ) or
+      ( ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('9', '>=') )%}
 include /etc/nginx/modules-enabled/*.conf;
 {% endif %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -3,8 +3,8 @@ user {{ nginx_user }};
 worker_processes {{ nginx_worker_processes }};
 pid /run/nginx.pid;
 
-{% if ( ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('18.04', '>=') ) or
-      ( ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('9', '>=') )%}
+{% if ( ansible_distribution == 'Ubuntu' and ( ansible_distribution_version is version_compare('18.04', '>=') ) ) or
+      ( ansible_distribution == 'Debian' and ( ansible_distribution_version is version_compare('9', '>=') ) ) %}
 include /etc/nginx/modules-enabled/*.conf;
 {% endif %}
 
@@ -61,7 +61,8 @@ http {
 
   # include /etc/nginx/naxsi_core.rules;
 
-  {% if ansible_distribution != 'Ubuntu' or ansible_distribution_version != '18.04' %}
+  {% if ( ansible_distribution == 'Ubuntu' and ( ansible_distribution_version is version_compare('18.04', '<') ) ) or
+        ( ansible_distribution == 'Debian' and ( ansible_distribution_version is version_compare('9', '<') ) ) %}
   ##
   # Phusion Passenger config
   ##


### PR DESCRIPTION
* Added a task to make sure that [dirmngr](https://packages.debian.org/stretch/dirmngr) is installed (because is used by apt-key at run-time)
* Added a variable to let users specify a custom keyserver port for apt public key download (that is part of the Passenger installation)
* Made role compatible with Debian 9, improved compatibility with newer Debian and Ubuntu
