### PR TITLE
Change ubuntu keyserver

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 # Passenger repository setup.
 - name: Add Passenger apt key.
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: hkp://keyserver.ubuntu.com:80
     id: 561F9B9CAC40B2F7
     state: present
 


### PR DESCRIPTION
Fix issue:

FAILED! => {"changed": false, "cmd": "/usr/bin/apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv 561F9B9CAC40B2F7", "msg": "Error fetching key 561F9B9CAC40B2F7 from keyserver: keyserver.ubuntu.com", "rc": 2, "stderr": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: keyserver receive failed: Connection timed out\n", "stderr_lines": ["Warning: apt-key output should not be parsed (stdout is not a terminal)", "gpg: keyserver receive failed: Connection timed out"], "stdout": "Executing: /tmp/apt-key-gpghome.lXbhfmrp0B/gpg.1.sh --no-tty --keyserver keyserver.ubuntu.com --recv 561F9B9CAC40B2F7\n", "stdout_lines": ["Executing: /tmp/apt-key-gpghome.lXbhfmrp0B/gpg.1.sh --no-tty --keyserver keyserver.ubuntu.com --recv 561F9B9CAC40B2F7"]}